### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^22.0.0",
+    "eslint": "^9.17.0",
     "fastify": "^4.0.0-rc.2",
     "neostandard": "^0.12.0",
     "tap": "^16.0.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.